### PR TITLE
Bug script path

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,3 +1,6 @@
 ###############
 vLab DataIQ API
 ###############
+
+DataIQ, an unstructured dataset management and insights software, empowers organizations
+to identify, classify and move data between heterogeneous storage systems and the cloud.

--- a/README.rst
+++ b/README.rst
@@ -2,5 +2,6 @@
 vLab DataIQ API
 ###############
 
-DataIQ, an unstructured dataset management and insights software, empowers organizations
-to identify, classify and move data between heterogeneous storage systems and the cloud.
+DataIQ, an unstructured dataset management and insights software, empowers
+organizations to identify, classify and move data between heterogeneous storage
+systems and the cloud.

--- a/tests/test_vmware.py
+++ b/tests/test_vmware.py
@@ -158,7 +158,7 @@ class TestVMware(unittest.TestCase):
         fake_listdir.return_value = ['dataiq_installer_1.0.0.10_202003090706_v1.sh']
 
         script_name = vmware._get_install_script('1.0.0')
-        expected = 'dataiq_installer_1.0.0.10_202003090706_v1.sh'
+        expected = '/images/dataiq_installer_1.0.0.10_202003090706_v1.sh'
 
         self.assertEqual(script_name, expected)
 

--- a/vlab_dataiq_api/lib/worker/vmware.py
+++ b/vlab_dataiq_api/lib/worker/vmware.py
@@ -154,7 +154,7 @@ def _get_install_script(image):
     all_scripts = [x for x in os.listdir(const.VLAB_DATAIQ_IMAGES_DIR) if not x.endswith('.ova')]
     for script in all_scripts:
         if image ==  convert_name(script):
-            return script
+            return '{}/{}'.format(const.VLAB_DATAIQ_IMAGES_DIR, script)
     else:
         raise ValueError('Supplied version {} does not exist'.format(image))
 


### PR DESCRIPTION
Found this bug the _hard way_ 😅 

```
dataiq-worker_1      | [2020-03-26 17:42:17,311: ERROR/ForkPoolWorker-8] Task dataiq.create[8087cb56-65d3-472a-b791-9b689952178b] raised unexpected: FileNotFoundError(2, 'No such file or directory')
dataiq-worker_1      | Traceback (most recent call last):
dataiq-worker_1      |   File "/usr/lib/python3.6/site-packages/celery/app/trace.py", line 385, in trace_task
dataiq-worker_1      |     R = retval = fun(*args, **kwargs)
dataiq-worker_1      |   File "/usr/lib/python3.6/site-packages/celery/app/trace.py", line 650, in __protected_call__
dataiq-worker_1      |     return self.run(*args, **kwargs)
dataiq-worker_1      |   File "/usr/lib/python3.6/site-packages/vlab_dataiq_api/lib/worker/tasks.py", line 65, in create
dataiq-worker_1      |     resp['content'] = vmware.create_dataiq(username, machine_name, image, network, logger)
dataiq-worker_1      |   File "/usr/lib/python3.6/site-packages/vlab_dataiq_api/lib/worker/vmware.py", line 102, in create_dataiq
dataiq-worker_1      |     _upload_install_script(vcenter, the_vm, install_script)
dataiq-worker_1      |   File "/usr/lib/python3.6/site-packages/vlab_dataiq_api/lib/worker/vmware.py", line 174, in _upload_install_script
dataiq-worker_1      |     with open(install_script) as the_file:
dataiq-worker_1      | FileNotFoundError: [Errno 2] No such file or directory: 'dataiq_installer_1.0.0.10_202003090706_v1.sh'
```