### PR TITLE
Service configures network upon deployment now

### DIFF
--- a/tests/test_api_schema.py
+++ b/tests/test_api_schema.py
@@ -42,7 +42,7 @@ class TestDataIQViewSchema(unittest.TestCase):
 
         self.assertTrue(schema_valid)
 
-    def test_iamges_schema(self):
+    def test_images_schema(self):
         """The schema defined for GET on /images is valid"""
         try:
             Draft4Validator.check_schema(dataiq.DataIQView.IMAGES_SCHEMA)

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -39,6 +39,10 @@ class TestTasks(unittest.TestCase):
                               machine_name='dataiqBox',
                               image='0.0.1',
                               network='someLAN',
+                              static_ip='192.168.1.2',
+                              default_gateway='192.168.1.1',
+                              netmask='255.255.255.0',
+                              dns=['192.168.1.1'],
                               txn_id='myId')
         expected = {'content' : {'worked': True}, 'error': None, 'params': {}}
 
@@ -53,6 +57,10 @@ class TestTasks(unittest.TestCase):
                               machine_name='dataiqBox',
                               image='0.0.1',
                               network='someLAN',
+                              static_ip='192.168.1.2',
+                              default_gateway='192.168.1.1',
+                              netmask='255.255.255.0',
+                              dns=['192.168.1.1'],
                               txn_id='myId')
         expected = {'content' : {}, 'error': 'testing', 'params': {}}
 

--- a/tests/test_vmware.py
+++ b/tests/test_vmware.py
@@ -101,6 +101,10 @@ class TestVMware(unittest.TestCase):
                                        machine_name='DataIQBox',
                                        image='1.0.0',
                                        network='someLAN',
+                                       static_ip='10.7.7.2',
+                                       default_gateway='10.7.7.1',
+                                       netmask='255.255.255.0',
+                                       dns=['10.7.7.1'],
                                        logger=fake_logger)
         expected = {'myDataIQ': {'worked': True}}
 
@@ -127,6 +131,10 @@ class TestVMware(unittest.TestCase):
                                   machine_name='DataIQBox',
                                   image='1.0.0',
                                   network='someOtherLAN',
+                                  static_ip='10.7.7.2',
+                                  default_gateway='10.7.7.1',
+                                  netmask='255.255.255.0',
+                                  dns=['10.7.7.1'],
                                   logger=fake_logger)
 
     @patch.object(vmware.os, 'listdir')

--- a/vlab_dataiq_api/lib/worker/tasks.py
+++ b/vlab_dataiq_api/lib/worker/tasks.py
@@ -38,7 +38,8 @@ def show(self, username, txn_id):
 
 
 @app.task(name='dataiq.create', bind=True)
-def create(self, username, machine_name, image, network, txn_id):
+def create(self, username, machine_name, image, network,static_ip, default_gateway,
+           netmask, dns, txn_id):
     """Deploy a new instance of DataIQ
 
     :Returns: Dictionary
@@ -55,6 +56,18 @@ def create(self, username, machine_name, image, network, txn_id):
     :param network: The name of the network to connect the new DataIQ instance up to
     :type network: String
 
+    :param static_ip: The IPv4 address to assign to the VM
+    :type static_ip: String
+
+    :param default_gateway: The IPv4 address of the network gateway
+    :type default_gateway: String
+
+    :param netmask: The subnet mask of the network, i.e. 255.255.255.0
+    :type netmask: String
+
+    :param dns: A list of DNS servers to use.
+    :type dns: List
+
     :param txn_id: A unique string supplied by the client to track the call through logs
     :type txn_id: String
     """
@@ -62,7 +75,15 @@ def create(self, username, machine_name, image, network, txn_id):
     resp = {'content' : {}, 'error': None, 'params': {}}
     logger.info('Task starting')
     try:
-        resp['content'] = vmware.create_dataiq(username, machine_name, image, network, logger)
+        resp['content'] = vmware.create_dataiq(username,
+                                               machine_name,
+                                               image,
+                                               network,
+                                               static_ip,
+                                               default_gateway,
+                                               netmask,
+                                               dns,
+                                               logger)
     except ValueError as doh:
         logger.error('Task failed: {}'.format(doh))
         resp['error'] = '{}'.format(doh)


### PR DESCRIPTION
DataIQ requires a static IP and a configured hostname.

This will automatically be done when deploying a DataIQ machine now.